### PR TITLE
requirements-dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,5 @@
 -r requirements.txt
 pytest
 coverage
-lxml              # For test coverage in run_test.py
-coverage          # For test coverage in run_test.py
-pillow            # For loading images in documentation generation
-nbsphinx          # For converting ipynb in documentation
-pandoc            # For documentation Qt snapshot updates
-
-# Use dev version of PyInstaller to keep hooks up-to-date
-https://github.com/pyinstaller/pyinstaller/archive/develop.zip; sys_platform == "win32"
+twine
+sphinx

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,14 @@
+# List of development dependencies (documentation, tests...)
+# Those ARE NOT required for installation, at runtime or to build from source
+
+-r requirements.txt
+pytest
+coverage
+lxml              # For test coverage in run_test.py
+coverage          # For test coverage in run_test.py
+pillow            # For loading images in documentation generation
+nbsphinx          # For converting ipynb in documentation
+pandoc            # For documentation Qt snapshot updates
+
+# Use dev version of PyInstaller to keep hooks up-to-date
+https://github.com/pyinstaller/pyinstaller/archive/develop.zip; sys_platform == "win32"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # List of development dependencies (documentation, tests...)
 # Those ARE NOT required for installation, at runtime or to build from source
 
--r requirements.txt
+-e .[cli,cache]
 pytest
 coverage
 twine


### PR DESCRIPTION
I created a requirements-dev.txt file, to simplify the setup for contributors to the project.

It allows installing everything needed (tests, doc, extras_require) in a single command:

`pip install -r requirements-dev.txt`