### PR TITLE
Fix URL for broadcasting tx on trest.Bitcoin.com

### DIFF
--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -83,7 +83,7 @@ class BitcoinDotComAPI():
     TEST_ENDPOINT = 'https://trest.bitcoin.com/v2/'
     TEST_ADDRESS_API = TEST_ENDPOINT + 'address/details/{}'
     TEST_UNSPENT_API = TEST_ENDPOINT + 'address/utxo/{}'
-    TEST_TX_PUSH_API = TEST_ENDPOINT + '/rawtransactions/sendRawTransaction/{}'
+    TEST_TX_PUSH_API = TEST_ENDPOINT + 'rawtransactions/sendRawTransaction/{}'
     TEST_TX_API = TEST_ENDPOINT + 'transaction/details/{}'
     TEST_TX_AMOUNT_API = TEST_TX_API
     TEST_RAW_API = TEST_ENDPOINT + 'transaction/details/{}'


### PR DESCRIPTION
Currently if the Bitcash SDK tries to send raw transactions to the testnet using the trest.bitcoin.com REST service, it will fail due to an incorrect RESTful path. The commit in this PR adjusts the path to be the correct one.