### PR TITLE
Remove incorrect tests and Add new tests for testnet

### DIFF
--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -136,12 +136,6 @@ class TestPublicKeyToAddress:
             public_key_to_address(PUBLIC_KEY_COMPRESSED[:-1])
 
     def test_public_key_to_address_test_compressed(self):
-        assert public_key_to_address(PUBLIC_KEY_COMPRESSED, version='test') == BITCOIN_ADDRESS_TEST_COMPRESSED
-
-    def test_public_key_to_address_test_uncompressed(self):
-        assert public_key_to_address(PUBLIC_KEY_UNCOMPRESSED, version='test') == BITCOIN_ADDRESS_TEST
-
-    def test_public_key_to_address_test_compressed(self):
         assert public_key_to_address(PUBLIC_KEY_COMPRESSED, version='test') == BITCOIN_CASHADDRESS_TEST_COMPRESSED
 
     def test_public_key_to_address_test_uncompressed(self):

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -90,6 +90,9 @@ class TestWIFToBytes:
     def test_compressed(self):
         assert wif_to_bytes(WALLET_FORMAT_COMPRESSED_MAIN) == (PRIVATE_KEY_BYTES, True, 'main')
 
+    def test_testnet_compressed(self):
+        assert wif_to_bytes(WALLET_FORMAT_COMPRESSED_TEST) == (PRIVATE_KEY_BYTES, True, 'test')
+
     def test_invalid_network(self):
         with pytest.raises(ValueError):
             wif_to_bytes(BITCOIN_ADDRESS)
@@ -104,6 +107,9 @@ class TestWIFChecksumCheck:
 
     def test_wif_checksum_check_compressed_success(self):
         assert wif_checksum_check(WALLET_FORMAT_COMPRESSED_MAIN)
+
+    def test_wif_checksum_check_test_compressed_success(self):
+        assert wif_checksum_check(WALLET_FORMAT_COMPRESSED_TEST)
 
     def test_wif_checksum_check_decode_failure(self):
         assert not wif_checksum_check(BITCOIN_ADDRESS[:-1])
@@ -159,7 +165,9 @@ def test_point_to_public_key():
 
 def test_address_to_public_key_hash():
     assert address_to_public_key_hash(BITCOIN_CASHADDRESS) == PUBKEY_HASH
+    assert address_to_public_key_hash(BITCOIN_CASHADDRESS_TEST) == PUBKEY_HASH
     assert address_to_public_key_hash(BITCOIN_CASHADDRESS_COMPRESSED) == PUBKEY_HASH_COMPRESSED
+    assert address_to_public_key_hash(BITCOIN_CASHADDRESS_TEST_COMPRESSED) == PUBKEY_HASH_COMPRESSED
     with pytest.raises(ValueError):
         address_to_public_key_hash(BITCOIN_CASHADDRESS_PAY2SH)
     with pytest.raises(ValueError):


### PR DESCRIPTION
Currently `tests/test_format.py` has mainnet and testnet checks to verify the functionality of `public_key_to_address()` . This function will always return a cash address format (i.e. `bchtest:qzfyvx77v2pmgc0vulwlfkl3uzjgh5gnmqjxnsx26x` ), but never a legacy address (i.e. `mtrNwJxS1VyHYn3qBY1Qfsm3K3kh1mGRMS` ).

There are two (duplicate) instances of the `test_public_key_to_address_test_compressed()` and `test_public_key_to_address_test_uncompressed()` tests, and it seems **_pytest_** only uses the latter duplicates to test with. If the names of these functions are changed to something unique, **_pytest_** will actually run them and they both fail as seen here:

<img width="1782" alt="failed_test" src="https://user-images.githubusercontent.com/22279374/95309861-de808700-08b5-11eb-8771-f054cf8a41e6.png">

These tests are broken as they attempt to assert that a cash address is equal to a legacy address.

