### PR TITLE
Remove bitcore

### DIFF
--- a/bitcash/exceptions.py
+++ b/bitcash/exceptions.py
@@ -8,3 +8,7 @@ class InvalidAddress(Exception):
 
 class InvalidNetwork(Exception):
     pass
+
+
+class InvalidEndpointURLProvided(Exception):
+    pass

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -18,7 +18,7 @@ class BitcoinDotComAPI:
 
     def __init__(self, network_endpoint: str):
         try:
-            assert type(network_endpoint) == str
+            assert isinstance(network_endpoint, str)
             assert network_endpoint[:4] == "http"
             assert network_endpoint[-4:] == "/v2/"
         except AssertionError:

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -8,9 +8,8 @@ from bitcash.network.transaction import Transaction, TxPart
 # This class is the interface for Bitcash to interact with
 # Bitcoin.com based RESTful interfaces.
 
-DEFAULT_TIMEOUT = 30
 BCH_TO_SAT_MULTIPLIER = 100000000
-# TODO: Refactor all constants into a 'constants.py' file
+# TODO: Refactor constant above into a 'constants.py' file
 
 
 class BitcoinDotComAPI:
@@ -48,22 +47,22 @@ class BitcoinDotComAPI:
     def make_endpoint_url(self, path):
         return self.network_endpoint + self.PATHS[path]
 
-    def get_balance(self, address):
+    def get_balance(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("address").format(address)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         data = r.json()
         return data["balanceSat"] + data["unconfirmedBalanceSat"]
 
-    def get_transactions(self, address):
+    def get_transactions(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("address").format(address)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return r.json()["transactions"]
 
-    def get_transaction(self, txid):
+    def get_transaction(self, txid, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         response = r.json(parse_float=Decimal)
 
@@ -96,18 +95,18 @@ class BitcoinDotComAPI:
 
         return tx
 
-    def get_tx_amount(self, txid, txindex):
+    def get_tx_amount(self, txid, txindex, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         response = r.json(parse_float=Decimal)
         return (
             Decimal(response["vout"][txindex]["value"]) * BCH_TO_SAT_MULTIPLIER
         ).normalize()
 
-    def get_unspent(self, address):
+    def get_unspent(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("unspent").format(address)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return [
             Unspent(
@@ -120,13 +119,13 @@ class BitcoinDotComAPI:
             for tx in r.json()["utxos"]
         ]
 
-    def get_raw_transaction(self, txid):
+    def get_raw_transaction(self, txid, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r = requests.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return r.json(parse_float=Decimal)
 
-    def broadcast_tx(self, tx_hex):  # pragma: no cover
+    def broadcast_tx(self, tx_hex, *args, **kwargs):  # pragma: no cover
         api_url = self.make_endpoint_url("raw-tx").format(tx_hex)
-        r = requests.get(api_url)
+        r = requests.get(api_url, *args, **kwargs)
         return r.status_code == 200

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -1,0 +1,132 @@
+import requests
+from decimal import Decimal
+from bitcash.exceptions import InvalidEndpointURLProvided
+from bitcash.network import currency_to_satoshi
+from bitcash.network.meta import Unspent
+from bitcash.network.services import DEFAULT_TIMEOUT
+from bitcash.network.transaction import Transaction, TxPart
+
+# This class is the interface for Bitcash to interact with
+# Bitcoin.com based RESTful interfaces.
+
+BCH_TO_SAT_MULTIPLIER = 100000000
+# TODO: Refactor all constants into a 'constants.py' file
+
+
+class BitcoinDotComAPI:
+    """ rest.bitcoin.com API """
+
+    def __init__(self, network_endpoint: str):
+        try:
+            assert type(network_endpoint) == str
+            assert network_endpoint[:4] == "http"
+            assert network_endpoint[-4:] == "/v2/"
+        except AssertionError:
+            raise InvalidEndpointURLProvided()
+
+        self.network_endpoint = network_endpoint
+
+    # Default endpoints to use for this interface
+    DEFAULT_ENDPOINTS = {
+        "mainnet": "https://rest.bch.actorforth.org/v2/",
+        "testnet": "https://trest.bitcoin.com/v2/",
+        "regtest": "http://localhost:12500/v2/",
+    }
+
+    # Paths specific to rest.bitcoin.com-based endpoints
+    PATHS = {
+        "unspent": "address/utxo/{}",
+        "address": "address/details/{}",
+        "raw-tx": "rawtransactions/sendRawTransaction/{}",
+        "tx-details": "transaction/details/{}",
+    }
+
+    @classmethod
+    def get_default_endpoint(cls, network):
+        return cls.DEFAULT_ENDPOINTS[network]
+
+    def make_endpoint_url(self, path):
+        return self.network_endpoint + self.PATHS[path]
+
+    def get_balance(self, address):
+        api_url = self.make_endpoint_url("address").format(address)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        data = r.json()
+        return data["balanceSat"] + data["unconfirmedBalanceSat"]
+
+    def get_transactions(self, address):
+        api_url = self.make_endpoint_url("address").format(address)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        return r.json()["transactions"]
+
+    def get_transaction(self, txid):
+        api_url = self.make_endpoint_url("tx-details").format(txid)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        response = r.json(parse_float=Decimal)
+
+        tx = Transaction(
+            response["txid"],
+            response["blockheight"],
+            (Decimal(response["valueIn"]) * BCH_TO_SAT_MULTIPLIER).normalize(),
+            (Decimal(response["valueOut"]) * BCH_TO_SAT_MULTIPLIER).normalize(),
+            (Decimal(response["fees"]) * BCH_TO_SAT_MULTIPLIER).normalize(),
+        )
+
+        for txin in response["vin"]:
+            part = TxPart(txin["cashAddress"], txin["value"], txin["scriptSig"]["asm"])
+            tx.add_input(part)
+
+        for txout in response["vout"]:
+            addr = None
+            if (
+                "cashAddrs" in txout["scriptPubKey"]
+                and txout["scriptPubKey"]["cashAddrs"] is not None
+            ):
+                addr = txout["scriptPubKey"]["cashAddrs"][0]
+
+            part = TxPart(
+                addr,
+                (Decimal(txout["value"]) * BCH_TO_SAT_MULTIPLIER).normalize(),
+                txout["scriptPubKey"]["asm"],
+            )
+            tx.add_output(part)
+
+        return tx
+
+    def get_tx_amount(self, txid, txindex):
+        api_url = self.make_endpoint_url("tx-details").format(txid)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        response = r.json(parse_float=Decimal)
+        return (
+            Decimal(response["vout"][txindex]["value"]) * BCH_TO_SAT_MULTIPLIER
+        ).normalize()
+
+    def get_unspent(self, address):
+        api_url = self.make_endpoint_url("unspent").format(address)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        return [
+            Unspent(
+                currency_to_satoshi(tx["amount"], "bch"),
+                tx["confirmations"],
+                r.json()["scriptPubKey"],
+                tx["txid"],
+                tx["vout"],
+            )
+            for tx in r.json()["utxos"]
+        ]
+
+    def get_raw_transaction(self, txid):
+        api_url = self.make_endpoint_url("tx-details").format(txid)
+        r = requests.get(api_url, timeout=DEFAULT_TIMEOUT)
+        r.raise_for_status()
+        return r.json(parse_float=Decimal)
+
+    def broadcast_tx(self, tx_hex):  # pragma: no cover
+        api_url = self.make_endpoint_url("raw-tx").format(tx_hex)
+        r = requests.get(api_url)
+        return r.status_code == 200

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -3,12 +3,12 @@ from decimal import Decimal
 from bitcash.exceptions import InvalidEndpointURLProvided
 from bitcash.network import currency_to_satoshi
 from bitcash.network.meta import Unspent
-from bitcash.network.services import DEFAULT_TIMEOUT
 from bitcash.network.transaction import Transaction, TxPart
 
 # This class is the interface for Bitcash to interact with
 # Bitcoin.com based RESTful interfaces.
 
+DEFAULT_TIMEOUT = 30
 BCH_TO_SAT_MULTIPLIER = 100000000
 # TODO: Refactor all constants into a 'constants.py' file
 

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -22,7 +22,7 @@ class BitcoinDotComAPI:
             assert network_endpoint[:4] == "http"
             assert network_endpoint[-4:] == "/v2/"
         except AssertionError:
-            raise InvalidEndpointURLProvided()
+            raise InvalidEndpointURLProvided(f"Provided endpoint '{network_endpoint}' is not a valid URL for a Bitcoin.com-based REST endpoint")
 
         self.network_endpoint = network_endpoint
 

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -27,9 +27,10 @@ class BitcoinDotComAPI:
 
     # Default endpoints to use for this interface
     DEFAULT_ENDPOINTS = {
-        "mainnet": "https://rest.bch.actorforth.org/v2/",
-        "testnet": "https://trest.bitcoin.com/v2/",
-        "regtest": "http://localhost:12500/v2/",
+        "mainnet": ["https://rest.bch.actorforth.org/v2/",
+                    "https://rest.bitcoin.com/v2/"],
+        "testnet": ["https://trest.bitcoin.com/v2/"],
+        "regtest": ["http://localhost:12500/v2/"],
     }
 
     # Paths specific to rest.bitcoin.com-based endpoints
@@ -41,7 +42,7 @@ class BitcoinDotComAPI:
     }
 
     @classmethod
-    def get_default_endpoint(cls, network):
+    def get_default_endpoints(cls, network):
         return cls.DEFAULT_ENDPOINTS[network]
 
     def make_endpoint_url(self, path):

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -90,7 +90,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_balance(address)
+                return endpoint.get_balance(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -108,7 +108,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_transactions(address)
+                return endpoint.get_transactions(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -126,7 +126,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_transaction(txid)
+                return endpoint.get_transaction(txid, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -146,7 +146,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_tx_amount(txid, txindex)
+                return endpoint.get_tx_amount(txid, txindex, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -164,7 +164,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_unspent(address)
+                return endpoint.get_unspent(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -182,7 +182,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                return endpoint.get_raw_transaction(txid)
+                return endpoint.get_raw_transaction(txid, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
@@ -200,7 +200,7 @@ class NetworkAPI:
 
         for endpoint in get_endpoints_for(network):
             try:
-                success = endpoint.broadcast_tx(tx_hex)
+                success = endpoint.broadcast_tx(tx_hex, timeout=DEFAULT_TIMEOUT)
                 if not success:
                     continue
                 return

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -30,7 +30,7 @@ def get_endpoints_for(network):
     # Where 'N' is a number starting at 1 and increasing to
     # however many endpoints you'd like.
     # If neither of these env variables have been set, it returns
-    # the instantiated result of <NAME>.get_default_endpoint(network)
+    # the instantiated result of <NAME>.get_default_endpoints(network)
 
     endpoints = []
     for endpoint in ENDPOINT_ENV_VARIABLES.keys():
@@ -53,8 +53,8 @@ def get_endpoints_for(network):
                     finished = True
         else:
             defaults_endpoints = ENDPOINT_ENV_VARIABLES[endpoint].get_default_endpoints(network)
-            for default in defaults_endpoints:
-                endpoints.append(ENDPOINT_ENV_VARIABLES[endpoint](default))
+            for each in defaults_endpoints:
+                endpoints.append(ENDPOINT_ENV_VARIABLES[endpoint](each))
 
     return endpoints
 

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -91,10 +91,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_balance(address)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def get_transactions(cls, address, network="mainnet"):
@@ -109,10 +109,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_transactions(address)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def get_transaction(cls, txid, network="mainnet"):
@@ -127,10 +127,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_transaction(txid)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def get_tx_amount(cls, txid, txindex, network="mainnet"):
@@ -147,10 +147,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_tx_amount(txid, txindex)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def get_unspent(cls, address, network="mainnet"):
@@ -165,10 +165,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_unspent(address)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def get_raw_transaction(cls, txid, network="mainnet"):
@@ -183,10 +183,10 @@ class NetworkAPI:
         for endpoint in get_endpoints_for(network):
             try:
                 return endpoint.get_raw_transaction(txid)
-            except cls.IGNORED_ERRORS:
+            except cls.IGNORED_ERRORS:  # pragma: no cover
                 pass
 
-        raise ConnectionError("All APIs are unreachable.")
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
 
     @classmethod
     def broadcast_tx(cls, tx_hex, network="mainnet"):  # pragma: no cover

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -8,7 +8,7 @@ from bitcash.network.APIs.BitcoinDotComAPI import BitcoinDotComAPI
 ENDPOINT_ENV_VARIABLES = {"BITCOINCOM": BitcoinDotComAPI}
 
 # Default API call total time timeout
-DEFAULT_TIMEOUT = 4
+DEFAULT_TIMEOUT = 5
 
 BCH_TO_SAT_MULTIPLIER = 100000000
 

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -8,7 +8,7 @@ from bitcash.network.APIs.BitcoinDotComAPI import BitcoinDotComAPI
 ENDPOINT_ENV_VARIABLES = {"BITCOINCOM": BitcoinDotComAPI}
 
 # Default API call total time timeout
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 4
 
 BCH_TO_SAT_MULTIPLIER = 100000000
 

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -52,12 +52,9 @@ def get_endpoints_for(network):
                 else:
                     finished = True
         else:
-            endpoints.append(
-                ENDPOINT_ENV_VARIABLES[endpoint](
-                    ENDPOINT_ENV_VARIABLES[endpoint].get_default_endpoint(
-                        network)
-                )
-            )
+            defaults_endpoints = ENDPOINT_ENV_VARIABLES[endpoint].get_default_endpoints(network)
+            for default in defaults_endpoints:
+                endpoints.append(ENDPOINT_ENV_VARIABLES[endpoint](default))
 
     return endpoints
 

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -194,21 +194,24 @@ class TestBitcoinDotComAPI:
 
     def test_get_balance_mainnet_return_type(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert isinstance(endpoint.get_balance(MAIN_ADDRESS_USED1), int)
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert isinstance(this_endpoint.get_balance(MAIN_ADDRESS_USED1), int)
 
     def test_get_balance_mainnet_used(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert endpoint.get_balance(MAIN_ADDRESS_USED1) > 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_balance(MAIN_ADDRESS_USED1) > 0
 
     def test_get_balance_mainnet_unused(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert endpoint.get_balance(MAIN_ADDRESS_UNUSED) == 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_balance(MAIN_ADDRESS_UNUSED) == 0
 
     def test_get_balance_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -216,21 +219,24 @@ class TestBitcoinDotComAPI:
 
     def test_get_transactions_mainnet_return_type(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert iter(endpoint.get_transactions(MAIN_ADDRESS_USED1))
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert iter(this_endpoint.get_transactions(MAIN_ADDRESS_USED1))
 
     def test_get_transactions_mainnet_used(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert (len(endpoint.get_transactions(MAIN_ADDRESS_USED1)) >= 218)
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert (len(this_endpoint.get_transactions(MAIN_ADDRESS_USED1)) >= 218)
 
     def test_get_transactions_mainnet_unused(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert (len(endpoint.get_transactions(MAIN_ADDRESS_UNUSED)) == 0)
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert (len(this_endpoint.get_transactions(MAIN_ADDRESS_UNUSED)) == 0)
 
     def test_get_transactions_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -238,9 +244,10 @@ class TestBitcoinDotComAPI:
 
     def test_get_transaction_mainnet(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert len(str(endpoint.get_transaction(MAIN_TX))) >= 156
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(str(this_endpoint.get_transaction(MAIN_TX))) >= 156
 
     def test_get_transaction_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -248,9 +255,10 @@ class TestBitcoinDotComAPI:
 
     def test_get_tx_amount_mainnet(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert endpoint.get_tx_amount(MAIN_TX2, 1) == 546
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_tx_amount(MAIN_TX2, 1) == 546
 
     def test_get_tx_amount_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -258,21 +266,24 @@ class TestBitcoinDotComAPI:
 
     def test_get_unspent_mainnet_return_type(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert iter(endpoint.get_unspent(MAIN_ADDRESS_USED1))
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert iter(this_endpoint.get_unspent(MAIN_ADDRESS_USED1))
 
     def test_get_unspent_mainnet_used(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert len(endpoint.get_unspent(MAIN_ADDRESS_USED2)) >= 1
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_unspent(MAIN_ADDRESS_USED2)) >= 1
 
     def test_get_unspent_mainnet_unused(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert len(endpoint.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_unspent(MAIN_ADDRESS_UNUSED)) == 0
 
     def test_get_unspent_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -280,9 +291,10 @@ class TestBitcoinDotComAPI:
 
     def test_get_raw_transaction_mainnet(self):
         time.sleep(1)
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("mainnet"))
-        assert endpoint.get_raw_transaction(MAIN_TX)["txid"] == MAIN_TX
+        endpoints = BitcoinDotComAPI.get_default_endpoints("mainnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_raw_transaction(MAIN_TX)["txid"] == MAIN_TX
 
     def test_get_raw_transaction_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -294,62 +306,70 @@ class TestBitcoinDotComAPI:
     def test_get_balance_testnet_used(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert endpoint.get_balance(TEST_ADDRESS_USED2) > 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_balance(TEST_ADDRESS_USED2) > 0
 
     # @pytest.mark.skip
     def test_get_balance_testnet_unused(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert endpoint.get_balance(TEST_ADDRESS_UNUSED) == 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_balance(TEST_ADDRESS_UNUSED) == 0
 
     # @pytest.mark.skip
     def test_get_transaction_testnet(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert len(str(endpoint.get_transaction(TEST_TX2))) >= 156
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(str(this_endpoint.get_transaction(TEST_TX2))) >= 156
 
     # @pytest.mark.skip
     def test_get_transactions_testnet_used(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert len(endpoint.get_transactions(TEST_ADDRESS_USED2)) >= 444
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_transactions(TEST_ADDRESS_USED2)) >= 444
 
     # @pytest.mark.skip
     def test_get_transactions_testnet_unused(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert len(endpoint.get_transactions(TEST_ADDRESS_UNUSED)) == 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_transactions(TEST_ADDRESS_UNUSED)) == 0
 
     # @pytest.mark.skip
     def test_get_unspent_testnet_used(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert len(endpoint.get_unspent(TEST_ADDRESS_USED2)) >= 194
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_unspent(TEST_ADDRESS_USED2)) >= 194
 
     # @pytest.mark.skip
     def test_get_unspent_testnet_unused(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert len(endpoint.get_unspent(TEST_ADDRESS_UNUSED)) == 0
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert len(this_endpoint.get_unspent(TEST_ADDRESS_UNUSED)) == 0
 
     # @pytest.mark.skip
     def test_get_raw_transaction_testnet(self):
         # Marking as skip because BitcoinCom Testnet is currently unreliable
         # TODO: Remove once a new Testnet endpoint is added
-        endpoint = BitcoinDotComAPI(
-            BitcoinDotComAPI.get_default_endpoint("testnet"))
-        assert endpoint.get_raw_transaction(TEST_TX)["txid"] == TEST_TX
+        endpoints = BitcoinDotComAPI.get_default_endpoints("testnet")
+        for endpoint in endpoints:
+            this_endpoint = BitcoinDotComAPI(endpoint)
+            assert this_endpoint.get_raw_transaction(TEST_TX)["txid"] == TEST_TX

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -75,7 +75,7 @@ class TestNetworkAPI:
     def test_get_balance_mainnet(self):
         time.sleep(1)
         results = NetworkAPI.get_balance(MAIN_ADDRESS_USED2, network="mainnet")
-        assert type(results) == int
+        assert isinstance(results, int)
 
     def test_get_balance_mainnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -85,7 +85,7 @@ class TestNetworkAPI:
         time.sleep(1)
         results = NetworkAPI.get_transactions(MAIN_ADDRESS_USED1,
                                               network="mainnet")
-        assert type(results) == list
+        assert isinstance(results, list)
         assert len(results) > 0
 
     def test_get_transactions_mainnet_failure(self):
@@ -111,7 +111,7 @@ class TestNetworkAPI:
     def test_get_unspent_mainnet(self):
         time.sleep(1)
         results = NetworkAPI.get_unspent(MAIN_ADDRESS_USED2, network="mainnet")
-        assert type(results) == list
+        assert isinstance(results, list)
         for item in results:
             assert isinstance(item, Unspent)
 
@@ -133,7 +133,7 @@ class TestNetworkAPI:
         # TODO: Remove once a new Testnet endpoint is added
         time.sleep(1)
         results = NetworkAPI.get_balance(TEST_ADDRESS_USED2, network="testnet")
-        assert type(results) == int
+        assert isinstance(results, int)
 
     def test_get_balance_testnet_failure(self):
         with pytest.raises(ConnectionError):
@@ -154,7 +154,7 @@ class TestNetworkAPI:
         # TODO: Remove once a new Testnet endpoint is added
         time.sleep(1)
         results = NetworkAPI.get_unspent(TEST_ADDRESS_USED3, network="testnet")
-        assert type(results) == list
+        assert isinstance(results, list)
         for item in results:
             assert isinstance(item, Unspent)
 

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -3,7 +3,6 @@ import pytest
 import bitcash
 from bitcash.network.services import (
     BitcoinDotComAPI,
-    BitcoreAPI,
     NetworkAPI,
     set_service_timeout,
 )
@@ -254,62 +253,3 @@ class TestBitcoinDotComAPI:
             BitcoinDotComAPI.get_raw_transaction(TEST_TX, network="testnet")["txid"]
             == TEST_TX
         )
-
-
-@decorate_methods(catch_errors_raise_warnings, NetworkAPI.IGNORED_ERRORS)
-class TestBitcoreAPI:
-    def test_get_balance_return_type(self):
-        assert isinstance(
-            BitcoreAPI.get_balance(MAIN_ADDRESS_USED1, network="mainnet"), int
-        )
-
-    def test_get_balance_main_used(self):
-        assert BitcoreAPI.get_balance(MAIN_ADDRESS_USED1, network="mainnet") > 0
-
-    def test_get_balance_main_unused(self):
-        assert BitcoreAPI.get_balance(MAIN_ADDRESS_UNUSED, network="mainnet") == 0
-
-    def test_get_balance_test_used(self):
-        assert BitcoreAPI.get_balance(TEST_ADDRESS_USED2, network="testnet") > 0
-
-    def test_get_balance_test_unused(self):
-        assert BitcoreAPI.get_balance(TEST_ADDRESS_UNUSED, network="testnet") == 0
-
-    def test_get_transactions_return_type(self):
-        assert iter(BitcoreAPI.get_transactions(MAIN_ADDRESS_USED1, network="mainnet"))
-
-    # FIXME: Bitcore.io only returns 10 elements
-    # def test_get_transactions_main_used(self):
-    #     assert len(BitcoreAPI.get_transactions(MAIN_ADDRESS_USED1)) >= 218
-
-    def test_get_transactions_main_unused(self):
-        assert (
-            len(BitcoreAPI.get_transactions(MAIN_ADDRESS_UNUSED, network="mainnet"))
-            == 0
-        )
-
-    # FIXME: Bitcore.io only returns 10 elements
-    # def test_get_transactions_test_used(self):
-    #     assert len(BitcoreAPI.get_transactions_testnet(TEST_ADDRESS_USED2)) >= 444
-
-    def test_get_transactions_test_unused(self):
-        assert (
-            len(BitcoreAPI.get_transactions(TEST_ADDRESS_UNUSED, network="testnet"))
-            == 0
-        )
-
-    def test_get_unspent_return_type(self):
-        assert iter(BitcoreAPI.get_unspent(MAIN_ADDRESS_USED1, network="mainnet"))
-
-    def test_get_unspent_main_used(self):
-        assert len(BitcoreAPI.get_unspent(MAIN_ADDRESS_USED2, network="mainnet")) >= 1
-
-    def test_get_unspent_main_unused(self):
-        assert len(BitcoreAPI.get_unspent(MAIN_ADDRESS_UNUSED, network="mainnet")) == 0
-
-    # FIXME: Bitcore.io only returns 10 elements
-    # def test_get_unspent_test_used(self):
-    #     assert len(BitcoreAPI.get_unspent_testnet(TEST_ADDRESS_USED2)) >= 194
-
-    def test_get_unspent_test_unused(self):
-        assert len(BitcoreAPI.get_unspent(TEST_ADDRESS_UNUSED, network="testnet")) == 0

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -26,6 +26,13 @@ BITCOIN_CASHADDRESS_REGTEST_COMPRESSED = (
 )
 BITCOIN_CASHADDRESS_REGTEST_PAY2SH = "bchreg:prezv854vnyallagz5zuz5lmjkle8x2rpqnpxygxa9"
 
+VALID_ENDPOINT_URLS = ["https://rest.bch.actorforth.org/v2/",
+                       "https://rest.bitcoin.com/v2/"]
+
+INVALID_ENDPOINT_URLS = ["htp://fakesite.com/v2",
+                         "https://bitcom.org/",
+                         42]
+
 PRIVATE_KEY_BYTES = b"\xc2\x8a\x9f\x80s\x8fw\rRx\x03\xa5f\xcfo\xc3\xed\xf6\xce\xa5\x86\xc4\xfcJR#\xa5\xady~\x1a\xc3"
 PRIVATE_KEY_DER = (
     b"0\x81\x84\x02\x01\x000\x10\x06\x07*\x86H\xce=\x02\x01\x06"

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -176,16 +176,19 @@ class TestPrivateKey:
 
     def test_get_balance(self):
         private_key = PrivateKey(WALLET_FORMAT_MAIN)
+        time.sleep(1)  # Needed due to API rate limiting
         balance = int(private_key.get_balance())
         assert balance == private_key.balance
 
     def test_get_unspent(self):
         private_key = PrivateKey(WALLET_FORMAT_MAIN)
+        time.sleep(1)  # Needed due to API rate limiting
         unspent = private_key.get_unspents()
         assert unspent == private_key.unspents
 
     def test_get_transactions(self):
         private_key = PrivateKey(WALLET_FORMAT_MAIN)
+        time.sleep(1)  # Needed due to API rate limiting
         transactions = private_key.get_transactions()
         assert transactions == private_key.transactions
 
@@ -236,17 +239,26 @@ class TestPrivateKeyTestnet:
         private_key = PrivateKeyTestnet(WALLET_FORMAT_COMPRESSED_TEST)
         assert private_key.to_wif() == WALLET_FORMAT_COMPRESSED_TEST
 
+    @pytest.mark.skip
     def test_get_balance(self):
+        # Marking as skip because BitcoinCom Testnet is currently unreliable
+        # TODO: Remove once a new Testnet endpoint is added
         private_key = PrivateKeyTestnet(WALLET_FORMAT_TEST)
         balance = int(private_key.get_balance())
         assert balance == private_key.balance
 
+    @pytest.mark.skip
     def test_get_unspent(self):
+        # Marking as skip because BitcoinCom Testnet is currently unreliable
+        # TODO: Remove once a new Testnet endpoint is added
         private_key = PrivateKeyTestnet(WALLET_FORMAT_TEST)
         unspent = private_key.get_unspents()
         assert unspent == private_key.unspents
 
+    @pytest.mark.skip
     def test_get_transactions(self):
+        # Marking as skip because BitcoinCom Testnet is currently unreliable
+        # TODO: Remove once a new Testnet endpoint is added
         private_key = PrivateKeyTestnet(WALLET_FORMAT_TEST)
         transactions = private_key.get_transactions()
         assert transactions == private_key.transactions
@@ -282,7 +294,10 @@ class TestPrivateKeyTestnet:
         logging.debug(f"Current: {current}, Initial: {initial}")
         assert current < initial
 
+    @pytest.mark.skip
     def test_send_pay2sh(self):
+        # Marking as skip because BitcoinCom Testnet is currently unreliable
+        # TODO: Remove once a new Testnet endpoint is added
         """
         We don't yet support pay2sh, so we must throw an exception if we get one.
         Otherwise, we could send coins into an unrecoverable blackhole, needlessly.


### PR DESCRIPTION
This PR removes the deprecated Bitcore API as a possible endpoint.

It also now allows the library user to specify their own BitcoinDotCom based API endpoints via environmental variables.

A library user may set a single endpoint by using:
`BITCOINCOM_API_MAINNET=https://rest.yourwebsitehere.com/v2/`

Or they may choose to set up multiple endpoints by using:
```
BITCOINCOM_API_MAINNET_1=https://rest.firstwebsite.com/v2/
BITCOINCOM_API_MAINNET_2=https://rest.bch.anotherone.org/v2/
BITCOINCOM_API_MAINNET_3=https://rest.manychoices.cash/v2/
```

This change will keep looking for additional APIs in the environmental variables until it cannot find the next number (.._MAINNET_4 in the above example, as it was not set).

Please note it is not currently possible to set both the 'single' API endpoint and 'multiple' API endpoints (using the _1, _2, etc numbers) at the same time. 

You can also replace 'MAINNET' with any supported network, and the same effect will be had on both the single and multiple endpoint options.

Lastly, this PR puts in place a basic framework for extending Bitcash to use alternative REST APIs in the future. Once additional APIs are added, the environment variable checker will use the new APIs name to instantiate endpoints for that API. Using Insomnia as an example, the following would be a valid environmental variable:
`INSOMNIA_API_TESTNET=https://trest.apihosting.com/v2/`

More information about adding additional endpoints can be included in a future PR, but is out of the scope for this current PR.