### PR TITLE
Broadcast transaction with a POST request

### DIFF
--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -37,7 +37,7 @@ class BitcoinDotComAPI:
     PATHS = {
         "unspent": "address/utxo/{}",
         "address": "address/details/{}",
-        "raw-tx": "rawtransactions/sendRawTransaction/{}",
+        "raw-tx": "rawtransactions/sendRawTransaction",
         "tx-details": "transaction/details/{}",
     }
 
@@ -127,6 +127,6 @@ class BitcoinDotComAPI:
         return r.json(parse_float=Decimal)
 
     def broadcast_tx(self, tx_hex, *args, **kwargs):  # pragma: no cover
-        api_url = self.make_endpoint_url("raw-tx").format(tx_hex)
-        r = requests.get(api_url, *args, **kwargs)
+        api_url = self.make_endpoint_url("raw-tx")
+        r = requests.post(api_url, json={"hexes": [tx_hex]}, *args, **kwargs)
         return r.status_code == 200


### PR DESCRIPTION
This broadcasts transactions using a POST request instead of GET from
the rawtransactions/sendRawTransaction endpoint. This allows much larger
transactions to be broadcasted since URLs restrict the amount of data
you can pass in.
