### PR TITLE
Reuse HTTP connections

### DIFF
--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -1,4 +1,4 @@
-from bitcash.network import session
+from bitcash.network.http import session
 from decimal import Decimal
 from bitcash.exceptions import InvalidEndpointURLProvided
 from bitcash.network import currency_to_satoshi

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -1,4 +1,4 @@
-import requests
+from bitcash.network import session
 from decimal import Decimal
 from bitcash.exceptions import InvalidEndpointURLProvided
 from bitcash.network import currency_to_satoshi
@@ -50,20 +50,20 @@ class BitcoinDotComAPI:
 
     def get_balance(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("address").format(address)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         data = r.json()
         return data["balanceSat"] + data["unconfirmedBalanceSat"]
 
     def get_transactions(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("address").format(address)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return r.json()["transactions"]
 
     def get_transaction(self, txid, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         response = r.json(parse_float=Decimal)
 
@@ -98,7 +98,7 @@ class BitcoinDotComAPI:
 
     def get_tx_amount(self, txid, txindex, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         response = r.json(parse_float=Decimal)
         return (
@@ -107,7 +107,7 @@ class BitcoinDotComAPI:
 
     def get_unspent(self, address, *args, **kwargs):
         api_url = self.make_endpoint_url("unspent").format(address)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return [
             Unspent(
@@ -122,11 +122,11 @@ class BitcoinDotComAPI:
 
     def get_raw_transaction(self, txid, *args, **kwargs):
         api_url = self.make_endpoint_url("tx-details").format(txid)
-        r = requests.get(api_url, *args, **kwargs)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return r.json(parse_float=Decimal)
 
     def broadcast_tx(self, tx_hex, *args, **kwargs):  # pragma: no cover
         api_url = self.make_endpoint_url("raw-tx")
-        r = requests.post(api_url, json={"hexes": [tx_hex]}, *args, **kwargs)
+        r = session.post(api_url, json={"hexes": [tx_hex]}, *args, **kwargs)
         return r.status_code == 200

--- a/bitcash/network/__init__.py
+++ b/bitcash/network/__init__.py
@@ -5,9 +5,3 @@ from .rates import (
     satoshi_to_currency_cached,
 )
 from .services import NetworkAPI
-
-from requests import Session
-
-#Create a re-usable session object which re-uses connection, mantains a pool.
-session = Session()
-#Optional: Configure user-agent here so that upstream servers know which library/version is making the request

--- a/bitcash/network/__init__.py
+++ b/bitcash/network/__init__.py
@@ -5,3 +5,9 @@ from .rates import (
     satoshi_to_currency_cached,
 )
 from .services import NetworkAPI
+
+from requests import Session
+
+#Create a re-usable session object which re-uses connection, mantains a pool.
+session = Session()
+#Optional: Configure user-agent here so that upstream servers know which library/version is making the request

--- a/bitcash/network/http/__init__.py
+++ b/bitcash/network/http/__init__.py
@@ -3,3 +3,4 @@ from requests import Session
 #Create a re-usable session object which re-uses connection, mantains a pool.
 session = Session()
 #Optional: Configure user-agent here so that upstream servers know which library/version is making the request
+

--- a/bitcash/network/http/__init__.py
+++ b/bitcash/network/http/__init__.py
@@ -1,0 +1,5 @@
+from requests import Session
+
+#Create a re-usable session object which re-uses connection, mantains a pool.
+session = Session()
+#Optional: Configure user-agent here so that upstream servers know which library/version is making the request

--- a/bitcash/network/rates.py
+++ b/bitcash/network/rates.py
@@ -4,7 +4,7 @@ from functools import wraps
 from time import time
 
 import requests
-
+from bitcash.network import session
 from bitcash.utils import Decimal
 
 DEFAULT_CACHE_TIME = 60
@@ -127,7 +127,7 @@ class BitpayRates:
     @classmethod
     def currency_to_satoshi(cls, currency):
         headers = {"x-accept-version": "2.0.0", "Accept": "application/json"}
-        r = requests.get(cls.SINGLE_RATE + currency, headers=headers)
+        r = session.get(cls.SINGLE_RATE + currency, headers=headers)
         r.raise_for_status()
         rate = r.json()["data"]["rate"]
         return int(ONE / Decimal(rate) * BCH)
@@ -259,7 +259,7 @@ class CoinbaseRates:
 
     @classmethod
     def currency_to_satoshi(cls, currency):
-        r = requests.get(cls.SINGLE_RATE.format(currency))
+        r = session.get(cls.SINGLE_RATE.format(currency))
         r.raise_for_status()
         rate = r.json()["data"]["rates"][currency]
         return int(ONE / Decimal(rate) * BCH)

--- a/bitcash/network/rates.py
+++ b/bitcash/network/rates.py
@@ -4,7 +4,7 @@ from functools import wraps
 from time import time
 
 import requests
-from bitcash.network import session
+from bitcash.network.http import session
 from bitcash.utils import Decimal
 
 DEFAULT_CACHE_TIME = 60


### PR DESCRIPTION
Reuse http/https connections to speed-up requests and reduce load on client and server.

Currently each time the library needs to make a request, it makes a fresh TCP+TLS connection to the remote server, then do the request, then discard the TCP+TLS connection.

With this change, once a request has been done, the connection goes into an idle connection pool. then next time you want to make a request, it would take the previously established connection and reuse it.

For example, our backend is in France, and user is in Thailand having a round trip time of ~300ms. it would take minimum ~900ms for client to make a request and get a response.

Now if client does a `get_balance` and then `broadcast_tx`. In current code it would take minimum ~1800ms (900ms + 900ms) to do both requests

With this change it would take minimum ~1200ms (900ms + 300ms) since we don't need to re-initialize a new connection.

I have not tested this change.