### PR TITLE
Add support for P2SH

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,9 @@ Unreleased (see `master <https://github.com/ofek/bitcash>`_)
 - NetworkAPI.get_tx_amount() is now working and properly handles
   backends returning string or decimal values.
 
+- Wallets can pay to script hash. However, P2SH utxo spending is still
+  not supported.
+
 0.5.2 (2018-05-16)
 ------------------
 

--- a/bitcash/cashaddress.py
+++ b/bitcash/cashaddress.py
@@ -100,6 +100,18 @@ class Address:
             f"version: {self.version}\npayload: {self.payload}\nprefix: {self.prefix}"
         )
 
+    def __repr__(self):
+        return f"Address('{self.cash_address()}')"
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.cash_address() == other
+        elif isinstance(other, Address):
+            return self.cash_address() == other.cash_address()
+        else:
+            raise ValueError("Address can be compared to a string address"
+                             " or an instance of Address")
+
     def cash_address(self):
         version_bit = Address.VERSIONS[self.version]["version_bit"]
         payload = [version_bit] + self.payload

--- a/bitcash/format.py
+++ b/bitcash/format.py
@@ -47,12 +47,27 @@ def verify_sig(signature, data, public_key):
 def address_to_public_key_hash(address):
     address = Address.from_string(address)
 
-    if "P2PKH" not in address.version:
-        # Bitcash currently only has support for P2PKH transaction types
-        # P2SH and others will raise ValueError
-        raise ValueError("Bitcash currently only supports P2PKH addresses")
+    if "P2PKH" not in address.version and "P2SH" not in address.version:
+        # Bitcash currently only supports P2PKH, P2SH transaction outputs
+        # others will raise ValueError
+        raise ValueError("Bitcash currently only supports"
+                         " P2PKH/P2SH addresses")
 
     return bytes(address.payload)
+
+
+def version_of_address(address):
+    """Return version of a str address
+    """
+    address = Address.from_string(address)
+
+    if "P2PKH" in address.version:
+        return "P2PKH"
+    elif "P2SH" in address.version:
+        return "P2SH"
+    else:
+        raise ValueError("Bitcash currently only supports"
+                         " P2PKH/P2SH addresses")
 
 
 def bytes_to_wif(private_key, version="main", compressed=False):
@@ -118,12 +133,14 @@ def wif_checksum_check(wif):
 
 
 def public_key_to_address(public_key, version="main"):
-    # Currently Bitcash only support P2PKH (not P2SH)
-    VERSIONS = {"main": "P2PKH", "test": "P2PKH-TESTNET", "regtest": "P2PKH-REGTEST"}
+    # Currently Bitcash only support P2PKH (not P2SH) utxos
+    VERSIONS = {
+        "main": "P2PKH", "test": "P2PKH-TESTNET", "regtest": "P2PKH-REGTEST"
+    }
 
     try:
         version = VERSIONS[version]
-    except:
+    except Exception:
         raise ValueError("Invalid version: {}".format(version))
     # 33 bytes compressed, 65 uncompressed.
     length = len(public_key)

--- a/bitcash/format.py
+++ b/bitcash/format.py
@@ -56,20 +56,6 @@ def address_to_public_key_hash(address):
     return bytes(address.payload)
 
 
-def version_of_address(address):
-    """Return version of a str address
-    """
-    address = Address.from_string(address)
-
-    if "P2PKH" in address.version:
-        return "P2PKH"
-    elif "P2SH" in address.version:
-        return "P2SH"
-    else:
-        raise ValueError("Bitcash currently only supports"
-                         " P2PKH/P2SH addresses")
-
-
 def bytes_to_wif(private_key, version="main", compressed=False):
 
     if version == "test":

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -18,13 +18,13 @@ BITCOIN_CASHADDRESS_TEST = "bchtest:qzfyvx77v2pmgc0vulwlfkl3uzjgh5gnmqjxnsx26x"
 BITCOIN_CASHADDRESS_TEST_COMPRESSED = (
     "bchtest:qzvsaasdvw6mt9j2rs3gyps673gj86flev3z0s40ln"
 )
-BITCOIN_CASHADDRESS_TEST_PAY2SH = "bchtest:prezv854vnyallagz5zuz5lmjkle8x2rpqfas9t47r"
+BITCOIN_CASHADDRESS_TEST_PAY2SH = "bchtest:pp23x8hm0g8d6nrkesamaqeml3v6daeudv90694pv4"
 
 BITCOIN_CASHADDRESS_REGTEST = "bchreg:qzfyvx77v2pmgc0vulwlfkl3uzjgh5gnmqg6939eeq"
 BITCOIN_CASHADDRESS_REGTEST_COMPRESSED = (
     "bchreg:qzvsaasdvw6mt9j2rs3gyps673gj86flevt7e3kuu4"
 )
-BITCOIN_CASHADDRESS_REGTEST_PAY2SH = "bchreg:prezv854vnyallagz5zuz5lmjkle8x2rpqnpxygxa9"
+BITCOIN_CASHADDRESS_REGTEST_PAY2SH = "bchreg:pp23x8hm0g8d6nrkesamaqeml3v6daeudvlnvykj0n"
 
 VALID_ENDPOINT_URLS = ["https://rest.bch.actorforth.org/v2/",
                        "https://rest.bitcoin.com/v2/"]
@@ -57,6 +57,7 @@ PRIVATE_KEY_PEM = (
 
 PUBKEY_HASH = b"\x92F\x1b\xdeb\x83\xb4a\xec\xe7\xdd\xf4\xdb\xf1\xe0\xa4\x8b\xd1\x13\xd8"
 PUBKEY_HASH_COMPRESSED = b'\x99\x0e\xf6\rc\xb5\xb5\x96J\x1c"\x82\x06\x1a\xf4Q#\xe9?\xcb'
+PUBKEY_HASH_P2SH = b'U\x13\x1e\xfbz\x0e\xddLv\xcc;\xbe\x83;\xfcY\xa6\xf7<k'
 PUBLIC_KEY_COMPRESSED = b"\x03=\\(u\xc9\xbd\x11hu\xa7\x1a]\xb6L\xff\xcb\x139k\x16=\x03\x9b\x1d\x93'\x82H\x91\x80C4"
 PUBLIC_KEY_UNCOMPRESSED = (
     b"\x04=\\(u\xc9\xbd\x11hu\xa7\x1a]\xb6L\xff\xcb\x139k\x16=\x03"

--- a/tests/test_cashaddress.py
+++ b/tests/test_cashaddress.py
@@ -211,3 +211,10 @@ class TestAddress:
             str(Address(version="P2PKH", payload=[]))
             == "version: P2PKH\npayload: []\nprefix: bitcoincash"
         )
+
+    def test_eq(self):
+        address = Address.from_string(BITCOIN_CASHADDRESS)
+        assert address == BITCOIN_CASHADDRESS
+        assert address == address
+        with pytest.raises(ValueError):
+            address == 1

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -9,11 +9,9 @@ from bitcash.format import (
     point_to_public_key,
     public_key_to_coords,
     public_key_to_address,
-    public_key_to_address,
     verify_sig,
     wif_checksum_check,
     wif_to_bytes,
-    version_of_address,
 )
 from .samples import (
     BITCOIN_ADDRESS,
@@ -247,7 +245,9 @@ def test_address_to_public_key_hash():
         address_to_public_key_hash(BITCOIN_CASHADDRESS_TEST_COMPRESSED)
         == PUBKEY_HASH_COMPRESSED
     )
-    assert address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST) == PUBKEY_HASH
+    assert (
+        address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST) == PUBKEY_HASH
+    )
     assert (
         address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST_COMPRESSED)
         == PUBKEY_HASH_COMPRESSED
@@ -264,12 +264,3 @@ def test_address_to_public_key_hash():
         address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST_PAY2SH)
         == PUBKEY_HASH_P2SH
     )
-
-
-def test_version_of_address():
-    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_REGTEST_PAY2SH)
-    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_TEST_PAY2SH)
-    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_PAY2SH)
-    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS)
-    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS_TEST)
-    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS_REGTEST)

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -13,6 +13,7 @@ from bitcash.format import (
     verify_sig,
     wif_checksum_check,
     wif_to_bytes,
+    version_of_address,
 )
 from .samples import (
     BITCOIN_ADDRESS,
@@ -28,6 +29,7 @@ from .samples import (
     BITCOIN_CASHADDRESS_REGTEST_PAY2SH,
     PRIVATE_KEY_BYTES,
     PUBKEY_HASH,
+    PUBKEY_HASH_P2SH,
     BITCOIN_CASHADDRESS,
     BITCOIN_CASHADDRESS_TEST,
     BITCOIN_CASHADDRESS_TEST_COMPRESSED,
@@ -250,9 +252,24 @@ def test_address_to_public_key_hash():
         address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST_COMPRESSED)
         == PUBKEY_HASH_COMPRESSED
     )
-    with pytest.raises(ValueError):
+    assert(
         address_to_public_key_hash(BITCOIN_CASHADDRESS_PAY2SH)
-    with pytest.raises(ValueError):
+        == PUBKEY_HASH_P2SH
+    )
+    assert(
         address_to_public_key_hash(BITCOIN_CASHADDRESS_TEST_PAY2SH)
-    with pytest.raises(ValueError):
+        == PUBKEY_HASH_P2SH
+    )
+    assert(
         address_to_public_key_hash(BITCOIN_CASHADDRESS_REGTEST_PAY2SH)
+        == PUBKEY_HASH_P2SH
+    )
+
+
+def test_version_of_address():
+    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_REGTEST_PAY2SH)
+    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_TEST_PAY2SH)
+    assert "P2SH" == version_of_address(BITCOIN_CASHADDRESS_PAY2SH)
+    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS)
+    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS_TEST)
+    assert "P2PKH" == version_of_address(BITCOIN_CASHADDRESS_REGTEST)


### PR DESCRIPTION
Wallets can pay to script hash. 

However, P2SH utxo spending is not supported. Spending P2SH utxo will probably need a new wallet class.