### PR TITLE
Adds test for blockheight for all endpoints

### DIFF
--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -43,6 +43,7 @@ class BitcoinDotComAPI(BaseAPI):
         "address": "address/details/{}",
         "raw-tx": "rawtransactions/sendRawTransaction",
         "tx-details": "transaction/details/{}",
+        "block-height": "blockchain/getBlockCount",
     }
 
     @classmethod
@@ -51,6 +52,12 @@ class BitcoinDotComAPI(BaseAPI):
 
     def make_endpoint_url(self, path):
         return self.network_endpoint + self.PATHS[path]
+
+    def get_blockheight(self, *args, **kwargs):
+        api_url = self.make_endpoint_url("block-height")
+        r = session.get(api_url)
+        r.raise_for_status()
+        return r.json()
 
     def get_balance(self, address, *args, **kwargs):
         address = cashtokenaddress_to_address(address)

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -2,10 +2,11 @@ from bitcash.network.http import session
 from decimal import Decimal
 from bitcash.exceptions import InvalidEndpointURLProvided
 from bitcash.network import currency_to_satoshi
-from bitcash.network.APIs import BaseAPI
+from bitcash.network.APIs import BaseAPI, DEFAULT_CACHE_TIME
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
 from bitcash.format import cashtokenaddress_to_address
+from bitcash.utils import time_cache
 
 # This class is the interface for Bitcash to interact with
 # Bitcoin.com based RESTful interfaces.
@@ -53,6 +54,7 @@ class BitcoinDotComAPI(BaseAPI):
     def make_endpoint_url(self, path):
         return self.network_endpoint + self.PATHS[path]
 
+    @time_cache(DEFAULT_CACHE_TIME)
     def get_blockheight(self, *args, **kwargs):
         api_url = self.make_endpoint_url("block-height")
         r = session.get(api_url)

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -2,11 +2,10 @@ from bitcash.network.http import session
 from decimal import Decimal
 from bitcash.exceptions import InvalidEndpointURLProvided
 from bitcash.network import currency_to_satoshi
-from bitcash.network.APIs import BaseAPI, DEFAULT_CACHE_TIME
+from bitcash.network.APIs import BaseAPI
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
 from bitcash.format import cashtokenaddress_to_address
-from bitcash.utils import time_cache
 
 # This class is the interface for Bitcash to interact with
 # Bitcoin.com based RESTful interfaces.
@@ -54,10 +53,9 @@ class BitcoinDotComAPI(BaseAPI):
     def make_endpoint_url(self, path):
         return self.network_endpoint + self.PATHS[path]
 
-    @time_cache(DEFAULT_CACHE_TIME)
     def get_blockheight(self, *args, **kwargs):
         api_url = self.make_endpoint_url("block-height")
-        r = session.get(api_url)
+        r = session.get(api_url, *args, **kwargs)
         r.raise_for_status()
         return r.json()
 

--- a/bitcash/network/APIs/ChaingraphAPI.py
+++ b/bitcash/network/APIs/ChaingraphAPI.py
@@ -56,6 +56,27 @@ class ChaingraphAPI(BaseAPI):
     def get_default_endpoints(cls, network):
         return cls.DEFAULT_ENDPOINTS[network]
 
+    def get_blockheight(self, *args, **kwargs):
+        json_request = {
+            "query": """
+query GetBlockheight($node: String!) {
+  block(
+    limit: 1
+    order_by: { height: desc }
+    where: { accepted_by: { node: { name: { _like: $node } } } }
+  ) {
+    height
+  }
+}
+""",
+            "variables": {
+                "node": self.node_like,
+            },
+        }
+        json = self.send_request(json_request, *args, **kwargs)
+        blockheight = int(json["data"]["block"][0]["height"])
+        return blockheight
+
     def get_balance(self, address, *args, **kwargs):
         json_request = {
             "query": """

--- a/bitcash/network/APIs/ChaingraphAPI.py
+++ b/bitcash/network/APIs/ChaingraphAPI.py
@@ -1,9 +1,10 @@
 from bitcash.network.http import session
 from bitcash.exceptions import InvalidEndpointURLProvided
-from bitcash.network.APIs import BaseAPI
+from bitcash.network.APIs import BaseAPI, DEFAULT_CACHE_TIME
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
 from bitcash.cashaddress import Address
+from bitcash.utils import time_cache
 
 
 class ChaingraphAPI(BaseAPI):
@@ -56,6 +57,7 @@ class ChaingraphAPI(BaseAPI):
     def get_default_endpoints(cls, network):
         return cls.DEFAULT_ENDPOINTS[network]
 
+    @time_cache(DEFAULT_CACHE_TIME)
     def get_blockheight(self, *args, **kwargs):
         json_request = {
             "query": """

--- a/bitcash/network/APIs/ChaingraphAPI.py
+++ b/bitcash/network/APIs/ChaingraphAPI.py
@@ -1,10 +1,9 @@
 from bitcash.network.http import session
 from bitcash.exceptions import InvalidEndpointURLProvided
-from bitcash.network.APIs import BaseAPI, DEFAULT_CACHE_TIME
+from bitcash.network.APIs import BaseAPI
 from bitcash.network.meta import Unspent
 from bitcash.network.transaction import Transaction, TxPart
 from bitcash.cashaddress import Address
-from bitcash.utils import time_cache
 
 
 class ChaingraphAPI(BaseAPI):
@@ -57,7 +56,6 @@ class ChaingraphAPI(BaseAPI):
     def get_default_endpoints(cls, network):
         return cls.DEFAULT_ENDPOINTS[network]
 
-    @time_cache(DEFAULT_CACHE_TIME)
     def get_blockheight(self, *args, **kwargs):
         json_request = {
             "query": """

--- a/bitcash/network/APIs/__init__.py
+++ b/bitcash/network/APIs/__init__.py
@@ -1,10 +1,6 @@
 from abc import ABC, abstractmethod
 
 
-# default cache time for the blockheigt retrieval
-DEFAULT_CACHE_TIME = 120
-
-
 class BaseAPI(ABC):
     """
     Abstract class for API classes

--- a/bitcash/network/APIs/__init__.py
+++ b/bitcash/network/APIs/__init__.py
@@ -24,6 +24,15 @@ class BaseAPI(ABC):
         """
 
     @abstractmethod
+    def get_blockheight(self, *args, **kwargs):
+        """
+        Return the block height.
+
+        :returns: Blockheight
+        :rtype: ``int``
+        """
+
+    @abstractmethod
     def get_balance(self, address, *args, **kwargs):
         """
         Returns balance of an address

--- a/bitcash/network/APIs/__init__.py
+++ b/bitcash/network/APIs/__init__.py
@@ -1,6 +1,10 @@
 from abc import ABC, abstractmethod
 
 
+# default cache time for the blockheigt retrieval
+DEFAULT_CACHE_TIME = 120
+
+
 class BaseAPI(ABC):
     """
     Abstract class for API classes

--- a/bitcash/network/services.py
+++ b/bitcash/network/services.py
@@ -4,6 +4,7 @@ import requests
 # Import supported endpoint APIs
 from bitcash.network.APIs.BitcoinDotComAPI import BitcoinDotComAPI
 from bitcash.network.APIs.ChaingraphAPI import ChaingraphAPI
+from bitcash.utils import time_cache
 
 # Dictionary of supported endpoint APIs
 ENDPOINT_ENV_VARIABLES = {
@@ -13,6 +14,9 @@ ENDPOINT_ENV_VARIABLES = {
 
 # Default API call total time timeout
 DEFAULT_TIMEOUT = 5
+
+# Default blockheigt cache timeout
+DEFAULT_BLOCKHEIGHT_CACHE_TIME = 300
 
 BCH_TO_SAT_MULTIPLIER = 100000000
 
@@ -103,6 +107,48 @@ def get_endpoints_for(network):
                     else:
                         endpoints.append(ENDPOINT_ENV_VARIABLES[endpoint](each))
 
+    return tuple(endpoints)
+
+
+@time_cache(max_age=DEFAULT_BLOCKHEIGHT_CACHE_TIME, cache_size=1)
+def _get_endpoints_blockheight(endpoints):
+    endpoints_blockheight = [0 for _ in range(len(endpoints))]
+
+    for i, endpoint in enumerate(endpoints):
+        try:
+            endpoints_blockheight[i] = endpoint.get_blockheight(timeout=DEFAULT_TIMEOUT)
+        except NetworkAPI.IGNORED_ERRORS:  # pragma: no cover
+            pass
+
+    if sum(endpoints_blockheight) == 0:
+        raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
+
+    return tuple(endpoints_blockheight)
+
+
+def get_sanitized_endpoints_for(network="mainnet"):
+    """Gets endpoints sanitized by their blockheights.
+    Solves the problem when an endpoint is stuck on an older block.
+
+    :param network: network in ["mainnet", "testnet", "regtest"].
+    """
+    endpoints = get_endpoints_for(network)
+
+    endpoints_blockheight = _get_endpoints_blockheight(endpoints)
+
+    # remove unreachable or un-synced endpoints
+    highest_blockheight = max(endpoints_blockheight)
+    pop_indices = []
+    for i in range(len(endpoints)):
+        if endpoints_blockheight[i] != highest_blockheight:
+            pop_indices.append(i)
+
+    if pop_indices:
+        endpoints = list(endpoints)
+        for i in sorted(pop_indices, reverse=True):
+            endpoints.pop(i)
+        endpoints = tuple(endpoints)
+
     return endpoints
 
 
@@ -123,43 +169,6 @@ class NetworkAPI:
     )
 
     @classmethod
-    def get_sanitized_endpoints_for(cls, network="mainnet"):
-        """Gets endpoints ordered by their blockheights.
-        Solves the problem when an endpoint is stuck on an older block.
-
-        :param network: network in ["mainnet", "testnet", "regtest"].
-        """
-        endpoints = get_endpoints_for(network)
-
-        endpoints_blockheight = [0 for _ in range(len(endpoints))]
-
-        for i, endpoint in enumerate(endpoints):
-            try:
-                endpoints_blockheight[i] = endpoint.get_blockheight(
-                    timeout=DEFAULT_TIMEOUT
-                )
-            except cls.IGNORED_ERRORS:  # pragma: no cover
-                pass
-
-        if sum(endpoints_blockheight) == 0:
-            raise ConnectionError("All APIs are unreachable.")  # pragma: no cover
-
-        # remove unreachable or un-synced endpoints
-        highest_blockheight = max(endpoints_blockheight)
-        pop_indices = []
-        for i in range(len(endpoints)):
-            if endpoints_blockheight[i] != highest_blockheight:
-                pop_indices.append(i)
-
-        if pop_indices:
-            endpoints = list(endpoints)
-            for i in sorted(pop_indices, reverse=True):
-                endpoints.pop(i)
-            endpoints = tuple(endpoints)
-
-        return endpoints
-
-    @classmethod
     def get_balance(cls, address, network="mainnet"):
         """Gets the balance of an address in satoshi.
 
@@ -168,7 +177,7 @@ class NetworkAPI:
         :raises ConnectionError: If all API services fail.
         :rtype: ``int``
         """
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_balance(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -185,7 +194,7 @@ class NetworkAPI:
         :raises ConnectionError: If all API services fail.
         :rtype: ``list`` of ``str``
         """
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_transactions(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -203,7 +212,7 @@ class NetworkAPI:
         :rtype: ``Transaction``
         """
 
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_transaction(txid, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -223,7 +232,7 @@ class NetworkAPI:
         :rtype: ``Decimal``
         """
 
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_tx_amount(txid, txindex, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -241,7 +250,7 @@ class NetworkAPI:
         :rtype: ``list`` of :class:`~bitcash.network.meta.Unspent`
         """
 
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_unspent(address, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -259,7 +268,7 @@ class NetworkAPI:
         :rtype: ``Transaction``
         """
 
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             try:
                 return endpoint.get_raw_transaction(txid, timeout=DEFAULT_TIMEOUT)
             except cls.IGNORED_ERRORS:  # pragma: no cover
@@ -277,7 +286,7 @@ class NetworkAPI:
         """
         success = None
 
-        for endpoint in cls.get_sanitized_endpoints_for(network):
+        for endpoint in get_sanitized_endpoints_for(network):
             _ = [end[0] for end in ChaingraphAPI.get_default_endpoints(network)]
             if endpoint in _ and network == "mainnet":
                 # Default chaingraph endpoints do not indicate failed broadcast

--- a/bitcash/utils.py
+++ b/bitcash/utils.py
@@ -72,11 +72,12 @@ def varint_to_int(val):
     return int.from_bytes(start_byte, "little")
 
 
-def time_cache(max_age):
+def time_cache(max_age: int, cache_size: int = 32):
     """
     Timed cache decorator to store a value until time-to-live
 
     :param max_age: Time, in seconds, untill when the value is invalidated.
+    :param cache_size: Size of LRU cache.
     """
 
     class ReturnValue:
@@ -85,7 +86,7 @@ def time_cache(max_age):
             self.expiry = expiry
 
     def _decorator(fn):
-        @functools.cache
+        @functools.lru_cache(maxsize=cache_size)
         def cache_fn(*args, **kwargs):
             value = fn(*args, **kwargs)
             expiry = time.monotonic() + max_age

--- a/bitcash/utils.py
+++ b/bitcash/utils.py
@@ -1,4 +1,6 @@
 import decimal
+import functools
+import time
 from binascii import hexlify
 
 
@@ -68,3 +70,36 @@ def varint_to_int(val):
     if start_byte == b"\xfd":
         return int.from_bytes(val.read(2), "little")
     return int.from_bytes(start_byte, "little")
+
+
+def time_cache(max_age):
+    """
+    Timed cache decorator to store a value until time-to-live
+
+    :param max_age: Time, in seconds, untill when the value is invalidated.
+    """
+
+    class ReturnValue:
+        def __init__(self, value, expiry):
+            self.value = value
+            self.expiry = expiry
+
+    def _decorator(fn):
+        @functools.cache
+        def cache_fn(*args, **kwargs):
+            value = fn(*args, **kwargs)
+            expiry = time.monotonic() + max_age
+            return ReturnValue(value, expiry)
+
+        @functools.wraps(fn)
+        def _wrapped(*args, **kwargs):
+            return_value = cache_fn(*args, **kwargs)
+            if return_value.expiry < time.monotonic():
+                # update the reference to the cache
+                return_value.value = fn(*args, **kwargs)
+                return_value.expiry = time.monotonic() + max_age
+            return return_value.value
+
+        return _wrapped
+
+    return _decorator

--- a/tests/network/APIs/test_BitcoinDotComAPI.py
+++ b/tests/network/APIs/test_BitcoinDotComAPI.py
@@ -78,6 +78,12 @@ class TestBitcoinDotComAPI:
         self.monkeypatch = MonkeyPatch()
         self.api = BitcoinDotComAPI("https://dummy.com/v2/")
 
+    def test_get_blockheight(self):
+        return_json = 800_000
+        self.monkeypatch.setattr(_bapi, "session", DummySession(return_json))
+        blockheight = self.api.get_blockheight()
+        assert blockheight == 800_000
+
     def test_get_balance(self):
         return_json = {
             "balanceSat": 2500,

--- a/tests/network/APIs/test_ChaingraphAPI.py
+++ b/tests/network/APIs/test_ChaingraphAPI.py
@@ -37,6 +37,20 @@ class TestChaingraphAPI:
         self.monkeypatch = MonkeyPatch()
         self.api = ChaingraphAPI("https://dummy.com/v1/graphql")
 
+    def test_get_blockheight(self):
+        return_json = {
+            "data": {
+                "block": [
+                    {
+                        "height": "123456"
+                    },
+                ]
+            }
+        }
+        self.monkeypatch.setattr(_capi, "session", DummySession(return_json))
+        blockheight = self.api.get_blockheight()
+        assert blockheight == 123456
+
     def test_get_balance(self):
         return_json = {
             "data": {

--- a/tests/network/APIs/test_ChaingraphAPI.py
+++ b/tests/network/APIs/test_ChaingraphAPI.py
@@ -41,9 +41,7 @@ class TestChaingraphAPI:
         return_json = {
             "data": {
                 "block": [
-                    {
-                        "height": "123456"
-                    },
+                    {"height": "123456"},
                 ]
             }
         }

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -12,6 +12,7 @@ from bitcash.network.services import (
     ChaingraphAPI,
     NetworkAPI,
     get_endpoints_for,
+    get_sanitized_endpoints_for,
     set_service_timeout,
 )
 from bitcash.network.transaction import Transaction
@@ -96,18 +97,19 @@ def mock_get_endpoints_for(network):
     )
 
 
-class TestNetworkAPI:
-    def test_get_ordered_endpoints_for(self):
-        monkeypatch = MonkeyPatch()
-        monkeypatch.setattr(_services, "get_endpoints_for", mock_get_endpoints_for)
-        endpoints = NetworkAPI.get_sanitized_endpoints_for("mainnet")
-        assert len(endpoints) == 4
-        for endpoint in endpoints:
-            assert endpoint.get_blockheight() == 4
-        # monkeypatch doesn't unset the attribute
-        # this fails the rest of the tests
-        monkeypatch.setattr(_services, "get_endpoints_for", get_endpoints_for)
+def test_get_ordered_endpoints_for():
+    monkeypatch = MonkeyPatch()
+    monkeypatch.setattr(_services, "get_endpoints_for", mock_get_endpoints_for)
+    endpoints = get_sanitized_endpoints_for("mainnet")
+    assert len(endpoints) == 4
+    for endpoint in endpoints:
+        assert endpoint.get_blockheight() == 4
+    # monkeypatch doesn't unset the attribute
+    # this fails the rest of the tests
+    monkeypatch.setattr(_services, "get_endpoints_for", get_endpoints_for)
 
+
+class TestNetworkAPI:
     # Mainnet
     def test_get_balance_mainnet(self):
         time.sleep(1)

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -100,11 +100,10 @@ class TestNetworkAPI:
     def test_get_ordered_endpoints_for(self):
         monkeypatch = MonkeyPatch()
         monkeypatch.setattr(_services, "get_endpoints_for", mock_get_endpoints_for)
-        endpoints = NetworkAPI.get_ordered_endpoints_for(
-            network="mainnet",
-            remove_bad_endpoints=True,
-        )
+        endpoints = NetworkAPI.get_sanitized_endpoints_for("mainnet")
         assert len(endpoints) == 4
+        for endpoint in endpoints:
+            assert endpoint.get_blockheight() == 4
         # monkeypatch doesn't unset the attribute
         # this fails the rest of the tests
         monkeypatch.setattr(_services, "get_endpoints_for", get_endpoints_for)

--- a/tests/network/test_services.py
+++ b/tests/network/test_services.py
@@ -100,7 +100,7 @@ def mock_get_endpoints_for(network):
 def test_get_ordered_endpoints_for():
     monkeypatch = MonkeyPatch()
     monkeypatch.setattr(_services, "get_endpoints_for", mock_get_endpoints_for)
-    endpoints = get_sanitized_endpoints_for("mainnet")
+    endpoints = get_sanitized_endpoints_for("mock_mainnet")
     assert len(endpoints) == 4
     for endpoint in endpoints:
         assert endpoint.get_blockheight() == 4


### PR DESCRIPTION
A method is added to NetworkAPI that sanitizes the endpoints; where the endpoints that are unreachable or are un-synced (based on their given blockheight) are removed. 

This fixes issues like #140 