### PR TITLE
Remove rest.Bitcoin.com

### DIFF
--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -33,7 +33,7 @@ class BitcoinDotComAPI(BaseAPI):
     # Default endpoints to use for this interface
     DEFAULT_ENDPOINTS = {
         "mainnet": ["https://rest.bch.actorforth.org/v2/"],
-        "testnet": ["https://trest.bitcoin.com/v2/"],
+        "testnet": [],
         "regtest": ["http://localhost:12500/v2/"],
     }
 

--- a/bitcash/network/APIs/BitcoinDotComAPI.py
+++ b/bitcash/network/APIs/BitcoinDotComAPI.py
@@ -32,10 +32,7 @@ class BitcoinDotComAPI(BaseAPI):
 
     # Default endpoints to use for this interface
     DEFAULT_ENDPOINTS = {
-        "mainnet": [
-            "https://rest.bch.actorforth.org/v2/",
-            "https://rest.bitcoin.com/v2/",
-        ],
+        "mainnet": ["https://rest.bch.actorforth.org/v2/"],
         "testnet": ["https://trest.bitcoin.com/v2/"],
         "regtest": ["http://localhost:12500/v2/"],
     }

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+import os
+import copy
 import pytest
 
 
@@ -10,3 +12,12 @@ def pytest_addoption(parser):
 def pytest_runtest_setup(item):
     if "regtest" in item.keywords and not item.config.getoption("--regtest"):
         pytest.skip("need --regtest option to run this test")
+
+
+@pytest.fixture(scope="function")
+def reset_environ():
+    """Reset os.environ after each test."""
+    original_environ = copy.deepcopy(os.environ)
+    yield
+    os.environ.clear()
+    os.environ.update(original_environ)


### PR DESCRIPTION
Remove rest.Bitcoin.com (and trest.bitcoin.com) from default `BitcoinDotComAPI` endpoints, as it has been defunct for a long time.