### PR TITLE
Fix get_unspent when utxo has no tokens

### DIFF
--- a/bitcash/network/APIs/FulcrumProtocolAPI.py
+++ b/bitcash/network/APIs/FulcrumProtocolAPI.py
@@ -276,7 +276,7 @@ class FulcrumProtocolAPI(BaseAPI):
             else:
                 nft_commitment = bytes.fromhex(nft["commitment"])
                 nft_capability = nft["capability"]
-            token_amount = int(token_data.get("amount"))
+            token_amount = int(token_data.get("amount", "0"))
             # add unspent
             unspents.append(
                 Unspent(


### PR DESCRIPTION
Calling get_unspent() on an address with a utxo that has no tokens would result in `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`.